### PR TITLE
Adjust time formatting in spreadsheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ async function addToWorkbook(folder, driveId = null) {
 				if (!['.nsp', '.nsz', '.xci'].includes(extension)) continue;
 				
 				sheet.cell(i,1).string(file.name);
-				sheet.cell(i,2).string(moment(file.modifiedTime).format('M/D/YYYY H:m:s'));
+				sheet.cell(i,2).string(moment(file.modifiedTime).format('M/D/YYYY H:mm:ss'));
 				sheet.cell(i,3).string(getFormattedSize(file.size));
 				sheet.cell(i,3).comment(`${file.size} B`);
 				sheet.cell(i,4).string(file.md5Checksum);


### PR DESCRIPTION
Moment documentation indicates s and m are for seconds and minutes but doesn't really define a difference other than it looked like it was for how granular you wanted it.  Changing m to mm and s to ss on line 395 makes the time more readable.  Previously it might end up as 1/24/2020 3:2:5 as an example.  Now that same stamp will come through as 1/24/2020 3:02:05.